### PR TITLE
new registry url

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 TANGOGQL_REPO_PATH=<Path to local TangoGQL repository clone>
 WEBJIVE_REPO_PATH=<Path to local WebJive repository clone>
-SKA_DOCKER_REGISTRY=ska-registry.av.it.pt/ska-docker
+SKA_DOCKER_REGISTRY=nexus.engageska-portugal.pt/ska-docker


### PR DESCRIPTION
The docker registry has been migrated to the Nexus repository (nexus.engageska-portugal.pt) in order to have all repositories concentrated in one place. By that, ska-registry.av.it.pt will no longer be available.