### PR TITLE
AT2-66 Enabler - Provide a reference set of images for webjive and tangogql  for use by the System team

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 TANGOGQL_REPO_PATH=<Path to local TangoGQL repository clone>
 WEBJIVE_REPO_PATH=<Path to local WebJive repository clone>
-SKA_DOCKER_REGISTRY=ska-registry.av.it.pt/ska-docker
+SKA_DOCKER_REGISTRY=nexus.engageska-portugal.pt/ska-docker

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ This table describes which services come with which service stack.
 | webjive.dev            | :heavy_check_mark: | :heavy_check_mark: |        :x:         | :heavy_check_mark:* |
 | webjive.dev.testdevice | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:* |
 \* Dev mode uses `npm start` rather than serving the app using nginx.  
+### Integration image
+The team provide a reference release of the current webjive system in the form of a set of docker images stored on the SKA docker hub
+
+These represent a relatively stable, but not necessarily functionally complete version of the webjive and TangGQL components.
+
+|Authentication server|webjive-develop_auth       |
+|TangoGQL             |webjive-develop_tangogql   |
+|Dashboard repository |webjive-develop_dashboards | 
+|Webjive              |webjive-develop_webjive    |
+
+A local docker environment of these components correctly configured together with the necessary supporting images (such as the system images for tangodb and tangocs) can be built locally by running the docker compose file:
+
+``` bash
+ docker-compose -f webjive.tangogql.integration.yml up -d
+```
+Then open `http://localhost:22484/testdb` in your chosen browser.
+
+
 
 More complete usage can be found by building the docs.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The team provide a reference release of the current webjive system in the form o
 
 These represent a relatively stable, but not necessarily functionally complete version of the webjive and TangGQL components.
 
+|Component            |Image name                 |
+| --------------------| :-----------------------: |
 |Authentication server|webjive-develop_auth       |
 |TangoGQL             |webjive-develop_tangogql   |
 |Dashboard repository |webjive-develop_dashboards | 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This table describes which services come with which service stack.
 ### Integration image
 The team provide a reference release of the current webjive system in the form of a set of docker images stored on the SKA docker hub
 
-These represent a relatively stable, but not necessarily functionally complete version of the webjive and TangGQL components.
+These represent a relatively stable, but not necessarily functionally complete version of the webjive and TangoGQL components.
 
 |Component            |Image name                 |
 | --------------------| :-----------------------: |

--- a/webjive.tangogql.integration.yml
+++ b/webjive.tangogql.integration.yml
@@ -1,0 +1,72 @@
+version: "3"
+services:
+  database:
+    image: ${SKA_DOCKER_REGISTRY}/tango-db:latest
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=1
+      - MYSQL_ROOT_PASSWORD=secret
+      - MYSQL_DATABASE=tango
+      - MYSQL_USER=tango
+      - MYSQL_PASSWORD=tango
+  control-system:
+    image: ${SKA_DOCKER_REGISTRY}/tango-cpp:latest
+    container_name: databaseds
+    hostname: databaseds
+    depends_on:
+      - database
+    environment:
+      - ORB_PORT=10000
+      - MYSQL_HOST=database:3306
+      - MYSQL_DATABASE=tango
+      - MYSQL_USER=tango
+      - MYSQL_PASSWORD=tango
+      - TANGO_HOST=127.0.0.1:10000
+    entrypoint:
+      - /usr/local/bin/wait-for-it.sh
+      - database:3306
+      - --timeout=30
+      - --strict
+      - --
+      - /usr/local/bin/DataBaseds
+      - "2"
+      - -ORBendPoint
+      - giop:tcp::10000
+  tangogql:
+    image: ${SKA_DOCKER_REGISTRY}/webjive-develop_tangogql:latest
+    restart: always
+    environment:
+      - TANGO_HOST=control-system:10000
+    labels:
+      - "traefik.frontend.rule=Host:localhost; PathPrefix: /testdb/db, /testdb/socket, /testdb/graphiql; ReplacePathRegex: ^/testdb/((?:db|socket|graphiql.*?)/?)/?$$ /$$1"
+      - "traefik.port=5004"
+  webjive:
+    image: ${SKA_DOCKER_REGISTRY}/webjive-develop_webjive:latest
+    labels:
+      - "traefik.frontend.rule=Host:localhost"
+      - "traefik.port=80"
+  auth:
+    image: ${SKA_DOCKER_REGISTRY}/webjive-develop_auth:latest
+    environment:
+      - SECRET=s3cr3t
+    labels:
+      - "traefik.frontend.rule=Host:localhost; PathPrefixStrip: /auth"
+      - "traefik.port=8080"
+  dashboards:
+    image: ${SKA_DOCKER_REGISTRY}/webjive-develop_dashboards:latest
+    environment:
+      - MONGO_HOST=mongodb://mongodb/dashboards
+      - SECRET=s3cr3t
+    labels:
+      - "traefik.frontend.rule=Host:localhost; PathPrefix: /dashboards"
+      - "traefik.port=3012"
+  mongodb:
+    image: mongo:3.6-stretch
+  traefik:
+    image: traefik:1.7-alpine
+    command: --docker
+    ports:
+      - 22484:80
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  
+    


### PR DESCRIPTION
This request is to add the docker-compose file for the integration set of images and some very brief notes to the project readme to cover how to use it and what it does.

It is being done at this stage to provide an enabler for the work the system team is doing. We will do something more comprehensive including automating the building of updated images later in the PI.