### PR TITLE
Fixes problem where the TMC images were failing to start with a 255 

### DIFF
--- a/tmc.yml
+++ b/tmc.yml
@@ -12,7 +12,7 @@ services:
       - TANGO_HOST=${TANGO_HOST}
     command: >
       sh -c "wait-for-it.sh ${TANGO_HOST} --timeout=30 --strict --
-             /venv/bin/python /app/tmcprototype/configure.py"
+             /venv/bin/python /app/tmcprototype/addDevicesAndProperties.py"
 
   dishmaster1:
     image: nexus.engageska-portugal.pt/tango-example/tmcprototype:latest


### PR DESCRIPTION
The root cause was that the latest version of 'configure' image on nexus was not picking up the device configurations because it could not find the file.

The name of the configuration file used has been changed and we need to reflect this in the yml for building/starting the TMC devices.